### PR TITLE
バックエンドの Azure Functions の Always on を無効にする（#18 のための段階的デプロイ）

### DIFF
--- a/iac/terraform/envs/dev/main.tf
+++ b/iac/terraform/envs/dev/main.tf
@@ -19,7 +19,8 @@ provider "azurerm" {
 module "core" {
   source = "../../modules/core"
 
-  workload_name                 = var.workload_name
-  env                           = var.env
-  backend_service_plan_sku_name = var.backend_service_plan_sku_name
+  workload_name = var.workload_name
+  env           = var.env
+  # backend_service_plan_sku_name = var.backend_service_plan_sku_name
+  backend_function_always_on = var.backend_function_always_on
 }

--- a/iac/terraform/envs/dev/main.tf
+++ b/iac/terraform/envs/dev/main.tf
@@ -19,6 +19,7 @@ provider "azurerm" {
 module "core" {
   source = "../../modules/core"
 
-  workload_name = var.workload_name
-  env           = var.env
+  workload_name                 = var.workload_name
+  env                           = var.env
+  backend_service_plan_sku_name = var.backend_service_plan_sku_name
 }

--- a/iac/terraform/envs/dev/variables.tf
+++ b/iac/terraform/envs/dev/variables.tf
@@ -7,7 +7,12 @@ variable "env" {
   default = "dev"
 }
 
-variable "backend_service_plan_sku_name" {
+# variable "backend_service_plan_sku_name" {
+#   type    = string
+#   default = "Y1"
+# }
+
+variable "backend_function_always_on" {
   type    = string
-  default = "Y1"
+  default = false
 }

--- a/iac/terraform/envs/dev/variables.tf
+++ b/iac/terraform/envs/dev/variables.tf
@@ -6,3 +6,8 @@ variable "env" {
   type    = string
   default = "dev"
 }
+
+variable "backend_service_plan_sku_name" {
+  type    = string
+  default = "Y1"
+}

--- a/iac/terraform/envs/prod/main.tf
+++ b/iac/terraform/envs/prod/main.tf
@@ -17,12 +17,14 @@ provider "azurerm" {
 }
 
 locals {
-  env = "prod"
+  env                           = "prod"
+  backend_service_plan_sku_name = "Y1"
 }
 
 module "core" {
   source = "../../modules/core"
 
-  workload_name = var.workload_name
-  env           = local.env
+  workload_name                 = var.workload_name
+  env                           = local.env
+  backend_service_plan_sku_name = local.backend_service_plan_sku_name
 }

--- a/iac/terraform/envs/prod/main.tf
+++ b/iac/terraform/envs/prod/main.tf
@@ -17,14 +17,16 @@ provider "azurerm" {
 }
 
 locals {
-  env                           = "prod"
-  backend_service_plan_sku_name = "Y1"
+  env = "prod"
+  # backend_service_plan_sku_name = "Y1"
+  backend_function_always_on = false
 }
 
 module "core" {
   source = "../../modules/core"
 
-  workload_name                 = var.workload_name
-  env                           = local.env
-  backend_service_plan_sku_name = local.backend_service_plan_sku_name
+  workload_name = var.workload_name
+  env           = local.env
+  # backend_service_plan_sku_name = local.backend_service_plan_sku_name
+  backend_function_always_on = local.backend_function_always_on
 }

--- a/iac/terraform/envs/staging/main.tf
+++ b/iac/terraform/envs/staging/main.tf
@@ -17,14 +17,17 @@ provider "azurerm" {
 }
 
 locals {
-  env                           = "staging"
-  backend_service_plan_sku_name = "Y1"
+  env = "staging"
+  # backend_service_plan_sku_name = "Y1"
+  backend_function_always_on = false
+
 }
 
 module "core" {
   source = "../../modules/core"
 
-  workload_name                 = var.workload_name
-  env                           = local.env
-  backend_service_plan_sku_name = local.backend_service_plan_sku_name
+  workload_name = var.workload_name
+  env           = local.env
+  # backend_service_plan_sku_name = local.backend_service_plan_sku_name
+  backend_function_always_on = local.backend_function_always_on
 }

--- a/iac/terraform/envs/staging/main.tf
+++ b/iac/terraform/envs/staging/main.tf
@@ -17,12 +17,14 @@ provider "azurerm" {
 }
 
 locals {
-  env = "staging"
+  env                           = "staging"
+  backend_service_plan_sku_name = "Y1"
 }
 
 module "core" {
   source = "../../modules/core"
 
-  workload_name = var.workload_name
-  env           = local.env
+  workload_name                 = var.workload_name
+  env                           = local.env
+  backend_service_plan_sku_name = local.backend_service_plan_sku_name
 }

--- a/iac/terraform/modules/backend/main.tf
+++ b/iac/terraform/modules/backend/main.tf
@@ -57,7 +57,8 @@ resource "azurerm_windows_function_app" "backend" {
   functions_extension_version = "~4"
 
   site_config {
-    always_on = var.service_plan_sku_name != "Y1"
+    always_on = var.function_always_on
+    # always_on = var.function_always_on || (var.service_plan_sku_name != "Y1")
     application_stack {
       node_version = "~16"
     }

--- a/iac/terraform/modules/backend/main.tf
+++ b/iac/terraform/modules/backend/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_service_plan" "backend" {
   resource_group_name = data.azurerm_resource_group.shared.name
   location            = data.azurerm_resource_group.shared.location
   os_type             = "Windows"
-  sku_name            = "P1v2"
+  sku_name            = var.service_plan_sku_name
 }
 
 resource "azurerm_windows_function_app" "backend" {
@@ -57,7 +57,7 @@ resource "azurerm_windows_function_app" "backend" {
   functions_extension_version = "~4"
 
   site_config {
-    always_on = true
+    always_on = var.service_plan_sku_name != "Y1"
     application_stack {
       node_version = "~16"
     }

--- a/iac/terraform/modules/backend/variables.tf
+++ b/iac/terraform/modules/backend/variables.tf
@@ -5,3 +5,8 @@ variable "workload_name" {
 variable "env" {
   type = string
 }
+
+variable "service_plan_sku_name" {
+  type    = string
+  default = "P1v2"
+}

--- a/iac/terraform/modules/backend/variables.tf
+++ b/iac/terraform/modules/backend/variables.tf
@@ -10,3 +10,8 @@ variable "service_plan_sku_name" {
   type    = string
   default = "P1v2"
 }
+
+variable "function_always_on" {
+  type    = string
+  default = false
+}

--- a/iac/terraform/modules/core/main.tf
+++ b/iac/terraform/modules/core/main.tf
@@ -9,7 +9,7 @@ module "backend" {
 module "frontend" {
   source = "../frontend"
 
-  workload_name     = var.workload_name
-  env               = var.env
-  backendResourceId = module.backend.functionResourceId
+  workload_name              = var.workload_name
+  env                        = var.env
+  linked_backend_resource_id = module.backend.functionResourceId
 }

--- a/iac/terraform/modules/core/main.tf
+++ b/iac/terraform/modules/core/main.tf
@@ -1,8 +1,9 @@
 module "backend" {
   source = "../backend"
 
-  workload_name = var.workload_name
-  env           = var.env
+  workload_name         = var.workload_name
+  env                   = var.env
+  service_plan_sku_name = var.backend_service_plan_sku_name
 }
 
 module "frontend" {

--- a/iac/terraform/modules/core/main.tf
+++ b/iac/terraform/modules/core/main.tf
@@ -4,6 +4,7 @@ module "backend" {
   workload_name         = var.workload_name
   env                   = var.env
   service_plan_sku_name = var.backend_service_plan_sku_name
+  function_always_on    = var.backend_function_always_on
 }
 
 module "frontend" {

--- a/iac/terraform/modules/core/variables.tf
+++ b/iac/terraform/modules/core/variables.tf
@@ -5,3 +5,8 @@ variable "workload_name" {
 variable "env" {
   type = string
 }
+
+variable "backend_service_plan_sku_name" {
+  type    = string
+  default = "P1v2"
+}

--- a/iac/terraform/modules/core/variables.tf
+++ b/iac/terraform/modules/core/variables.tf
@@ -10,3 +10,8 @@ variable "backend_service_plan_sku_name" {
   type    = string
   default = "P1v2"
 }
+
+variable "backend_function_always_on" {
+  type    = string
+  default = true
+}

--- a/iac/terraform/modules/frontend/main.tf
+++ b/iac/terraform/modules/frontend/main.tf
@@ -18,8 +18,8 @@ resource "azurerm_resource_group_template_deployment" "frontend" {
     "region" = {
       value = data.azurerm_resource_group.shared.location
     }
-    "backendResourceId" = {
-      value = var.backendResourceId
+    "linked_backend_resource_id" = {
+      value = var.linked_backend_resource_id
     }
     "staticSiteName" = {
       value = azurerm_static_site.frontend.name
@@ -33,7 +33,7 @@ resource "azurerm_resource_group_template_deployment" "frontend" {
     "region": {
       "type": "String"
     },
-    "backendResourceId": {
+    "linked_backend_resource_id": {
       "type": "String"
     },
     "staticSiteName": {
@@ -47,7 +47,7 @@ resource "azurerm_resource_group_template_deployment" "frontend" {
       "apiVersion": "2022-03-01",
       "name": "[concat(parameters('staticSiteName'), '/backend-api')]",
       "properties": {
-        "backendResourceId": "[parameters('backendResourceId')]",
+        "backendResourceId": "[parameters('linked_backend_resource_id')]",
         "region": "[parameters('region')]"
       }
     }

--- a/iac/terraform/modules/frontend/variables.tf
+++ b/iac/terraform/modules/frontend/variables.tf
@@ -6,6 +6,6 @@ variable "env" {
   type = string
 }
 
-variable "backendResourceId" {
+variable "linked_backend_resource_id" {
   type = string
 }


### PR DESCRIPTION
#18 を行うにあたり、App Service Plan を `Y1` に変更するには Azure Function の Always on の設定を無効にしなければならないことが分かった。同時に変更することはできなかったので、この PR で Always on を無効としておく。